### PR TITLE
feat: support the latest OpenAI model `chatgpt-4o-latest`

### DIFF
--- a/app/src/admin/channel.ts
+++ b/app/src/admin/channel.ts
@@ -119,6 +119,7 @@ export const ChannelInfos: Record<string, ChannelInfo> = {
       "gpt-4o-2024-08-06",
       "gpt-4o-mini",
       "gpt-4o-mini-2024-07-18",
+      "chatgpt-4o-latest",
       "dalle",
       "dall-e-2",
       "dall-e-3",

--- a/app/src/admin/datasets/charge.ts
+++ b/app/src/admin/datasets/charge.ts
@@ -69,7 +69,7 @@ export const pricing: PricingDataset = [
     output: 0.03,
   },
   {
-    models: ["gpt-4o", "gpt-4o-2024-05-13"],
+    models: ["gpt-4o", "gpt-4o-2024-05-13", "chatgpt-4o-latest"],
     input: 0.005,
     output: 0.015,
   },


### PR DESCRIPTION
 This also means we can save the steps to update the latest model.

 Reference:
 - https://x.com/OpenAIDevs/status/1823510395619000525
 - https://x.com/lmsysorg/status/1823515224064098546
 - https://x.com/lmsysorg/status/1823515229491515715
 - https://platform.openai.com/docs/models/gpt-4o

 > Dynamic model continuously updated to the current version of GPT-4o in ChatGPT. Intended for research and evaluation.
 >
 > We are releasing this model for developers and researchers to explore OpenAI's latest research. For production use, OpenAI recommends using dated GPT models, which are optimized for API usage.
 >
 > https://platform.openai.com/docs/models/gpt-4o#4ofootnote