### PR TITLE
Simplify apk upgrade process in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,11 +32,9 @@ RUN npm install -g pnpm && \
 FROM alpine
 
 # Install dependencies
-RUN apk update && \
-    apk upgrade && \
+RUN apk upgrade --no-cache && \
     apk add --no-cache wget ca-certificates tzdata && \
-    update-ca-certificates 2>/dev/null || true && \
-    rm -rf /var/cache/apk/*
+    update-ca-certificates 2>/dev/null || true
 
 # Set timezone
 RUN echo "Asia/Shanghai" > /etc/timezone && \


### PR DESCRIPTION
Use `apk upgrade` with `--no-cache`, just like `apk add`, so the `apk update` & `rm -rf /var/cache/apk/*` can be removed.